### PR TITLE
`Text.propTypes` is deprecated since 0.63

### DIFF
--- a/src/AnimatedEllipsis.js
+++ b/src/AnimatedEllipsis.js
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
-import { TextStyleProp, Animated, View, StyleSheet } from 'react-native';
+import { Animated, View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-
 
 export default class AnimatedEllipsis extends Component {
   static propTypes = {
     numberOfDots: PropTypes.number,
     animationDelay: PropTypes.number,
     minOpacity: PropTypes.number,
-    style: TextStyleProp,
+    style: PropTypes.object,
     useNativeDriver: PropTypes.bool
   };
 

--- a/src/AnimatedEllipsis.js
+++ b/src/AnimatedEllipsis.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Text, Animated, View, StyleSheet } from 'react-native';
+import { TextStyleProp, Animated, View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
 
@@ -8,7 +8,7 @@ export default class AnimatedEllipsis extends Component {
     numberOfDots: PropTypes.number,
     animationDelay: PropTypes.number,
     minOpacity: PropTypes.number,
-    style: Text.propTypes.style,
+    style: TextStyleProp,
     useNativeDriver: PropTypes.bool
   };
 


### PR DESCRIPTION
Can't find a clear solution for this right now, so I'm just setting styles to `PropTypes.object`.

Note: Tested using React Native for the Web.